### PR TITLE
In which our hero removes the trusted-host option to pip3 as unecessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN git clone https://github.com/OpenAssessItToolkit/openassessit_templates.git
 
 # Install any needed packages specified in openassessits requirements.txt
 RUN pip3 install wheel
-RUN pip3 install --trusted-host pypi.python.org -r openassessit/requirements.txt
+RUN pip3 install -r openassessit/requirements.txt
 
 # TODO: Install a webdriver https://www.blazemeter.com/blog/how-to-run-selenium-tests-in-docker
 


### PR DESCRIPTION
I suspect that bit was needed at some point, but it's not required now in order to safely retrieve packages. 